### PR TITLE
Add a parameter for minimum out degree of a node

### DIFF
--- a/src/Cinterface/analysis_C.cpp
+++ b/src/Cinterface/analysis_C.cpp
@@ -29,6 +29,7 @@ C_INTERFACE GenerateGraph(
 	float DownStep,
 	float DownSlope,
 	int max_step_connections,
+	int min_connections,
 	int core_count,
 	Graph** out_graph
 ){
@@ -46,6 +47,7 @@ C_INTERFACE GenerateGraph(
 		DownStep,
 		DownSlope,
 		max_step_connections,
+		min_connections,
 		core_count
 	);
 
@@ -67,6 +69,7 @@ C_INTERFACE GenerateGraphObstacles(
 	float DownStep,
 	float DownSlope,
 	int max_step_connections,
+	int min_connections,
 	int core_count,
 	const int* obstacle_ids,
 	const int* walkable_ids,
@@ -91,6 +94,7 @@ C_INTERFACE GenerateGraphObstacles(
 		DownStep,
 		DownSlope,
 		max_step_connections,
+		min_connections,
 		core_count
 	);
 

--- a/src/Cinterface/analysis_C.h
+++ b/src/Cinterface/analysis_C.h
@@ -58,6 +58,10 @@ namespace HF {
 	\param		max_step_connection		Multiplier for number of children to generate for each node. 
 										Increasing this value will increase the number of edges in the graph, 
 										and as a result the amount of memory the algorithm requires.
+			
+	\param		min_connections			The required out-degree for a node to be valid and stored.
+										This must be greater than 0 and equal or less than the total connections created from max_step_connections.
+										Default is 1. A value of 8 when max_step_connections=1 would be a grid.
 
 	\param		core_count				Number of cores to use. -1 will use all available cores, 
 										and 0 or 1 will run a serialized version of the algorithm.
@@ -112,6 +116,7 @@ C_INTERFACE GenerateGraph(
 	float DownStep,
 	float DownSlope,
 	int max_step_connection,
+	int min_connections,
 	int core_count,
 	HF::SpatialStructures::Graph** out_graph
 );
@@ -146,6 +151,10 @@ C_INTERFACE GenerateGraph(
 	\param		max_step_connection		Multiplier for number of children to generate for each node.
 										Increasing this value will increase the number of edges in the graph,
 										and as a result the amount of memory the algorithm requires.
+	
+	\param		min_connections			The required out-degree for a node to be valid and stored.
+										 This must be greater than 0 and equal or less than the total connections created from max_step_connections.
+										 Default is 1. A value of 8 when max_step_connections=1 would be a grid.
 
 	\param		core_count				Number of cores to use. -1 will use all available cores,
 										and 0 or 1 will run a serialized version of the algorithm.
@@ -205,6 +214,7 @@ C_INTERFACE GenerateGraphObstacles(
 	float DownStep,
 	float DownSlope,
 	int max_step_connection,
+	int min_connections,
 	int core_count,
 	const int* obstacle_ids,
 	const int* walkable_ids,

--- a/src/Cinterface/pathfinder_C.h
+++ b/src/Cinterface/pathfinder_C.h
@@ -97,6 +97,10 @@ namespace HF {
 		const int max_step_connections = 1;		// Multiplier for number of children to generate for each node.
 												// Increasing this value increases the number of edges in the graph,
 												// therefore increasing the memory footprint of the algorithm overall.
+			
+		const int min_connections = 1;          // The required out-degree for a node to be valid and stored.
+												// This must be greater than 0 and equal or less than the total connections created from max_step_connections.
+												// Default is 1. A value of 8 when max_step_connections=1 would be a grid.
 
 		const int core_count = -1;				// CPU core count. A value of (-1) will use all available cores.
 
@@ -109,7 +113,7 @@ namespace HF {
 
 		status = GenerateGraph(bvh, start_point.data(), spacing.data(), max_nodes,
 			up_step, down_step, up_slope, down_slope,
-			max_step_connections, core_count, &graph);
+			max_step_connections, min_connections, core_count, &graph);
 
 		if (status != 1) {
 			std::cerr << "Error at GenerateGraph, code: " << status << std::endl;

--- a/src/Cpp/analysismethods/src/graph_generator.cpp
+++ b/src/Cpp/analysismethods/src/graph_generator.cpp
@@ -201,8 +201,8 @@ namespace HF::GraphGenerator{
 			// add the edges to the graph and todo list in sequence
 			for (int i = 0; i < to_do_count; i++) {
 
-				// Only continue if there are edges for this node
-				if (!OutEdges[i].empty()) {
+				// Only continue if there are edges for this node and the number of edges is the minimum desired
+				if (!OutEdges[i].empty() && OutEdges.size() >= this->min_connections) {
 
 					// Iterate through each edge and add it to the graph / todolist
 					for (const auto& e : OutEdges[i]) {
@@ -246,25 +246,30 @@ namespace HF::GraphGenerator{
 			);
 
 			// Create edges
-			std::vector<graph_edge> edges = GetChildren(
+			std::vector<graph_edge> OutEdges = GetChildren(
 				real_parent,
 				children,
 				rt_ref,
 				params
 			);
 
-			// Add new nodes to the queue. It'll drop them if they
-			// already were evaluated, or already existed on the queue
-			for (auto edge : edges)
-				todo.PushAny(edge.child);
+			// Make
+			if (!OutEdges.empty() && OutEdges.size() >= this->min_connections)
+			{
 
-			// Add new edges to the graph
-			if (!edges.empty())
-				for (const auto& edge : edges)
-					G.addEdge(parent, edge.child, edge.score);
+				// Add new nodes to the queue. It'll drop them if they
+				// already were evaluated, or already existed on the queue
+				for (auto edge : OutEdges)
+					todo.PushAny(edge.child);
 
-			// Increment node count
-			++num_nodes;
+				// Add new edges to the graph
+				if (!OutEdges.empty())
+					for (const auto& edge : OutEdges)
+						G.addEdge(parent, edge.child, edge.score);
+
+				// Increment node count
+				num_nodes++;
+			}
 		}
 		return G;
 	}

--- a/src/Cpp/analysismethods/src/graph_generator.cpp
+++ b/src/Cpp/analysismethods/src/graph_generator.cpp
@@ -75,6 +75,7 @@ namespace HF::GraphGenerator{
 		real_t DownStep,
 		real_t DownSlope,
 		int max_step_connections,
+		int min_connections,
 		int cores,
 		real_t node_z_precision,
 		real_t node_spacing_precision,
@@ -100,6 +101,7 @@ namespace HF::GraphGenerator{
 		this->spacing = Spacing; 
 		this->core_count = cores;
 		this->max_step_connection = max_step_connections;
+		this->min_connections = min_connections;
 		
 		// Take the user defined start point and round it to the precision
 		// that the dhart package can handle. 

--- a/src/Cpp/analysismethods/src/graph_generator.cpp
+++ b/src/Cpp/analysismethods/src/graph_generator.cpp
@@ -202,7 +202,7 @@ namespace HF::GraphGenerator{
 			for (int i = 0; i < to_do_count; i++) {
 
 				// Only continue if there are edges for this node and the number of edges is the minimum desired
-				if (!OutEdges[i].empty() && OutEdges.size() >= this->min_connections) {
+				if (!OutEdges[i].empty() && OutEdges[i].size() >= this->min_connections) {
 
 					// Iterate through each edge and add it to the graph / todolist
 					for (const auto& e : OutEdges[i]) {

--- a/src/Cpp/analysismethods/src/graph_generator.h
+++ b/src/Cpp/analysismethods/src/graph_generator.h
@@ -347,6 +347,7 @@ namespace HF::GraphGenerator {
 		int max_nodes;			///< Maximum number of nodes to generate. If less than zero, generate nodes without a limit.
 		int core_count;			///< Number of cores to use for graph generation.
 
+		int min_connections;  ///< Minimum number of step connections for a node to be valid (minimum out degree of node)
 		int max_step_connection; ///< Multiplier for number of children to generate. The higher this is, the more directions there will be
 		real3 spacing;			///< Spacing between nodes. New nodes will be generated with atleast this much distance between them. 
 
@@ -414,9 +415,13 @@ namespace HF::GraphGenerator {
 			The maximum downward slope the graph can traverse. Any slopes steeper than this will be
 			considered inaccessible.
 
-			\param max_step_connections Multiplier for number of children to generate for each node. Increasing this value will
-			 increase the number of edges in the graph, and as a result the amount of memory the
-			 algorithm requires.
+			\param max_step_connections Multiplier for number of children to generate for each node. 
+			 Increasing this value will increase the number of edges in the graph, 
+			 and as a result the amount of memory the algorithm requires.
+
+			\param min_connections The required out-degree for a node to be valid and stored.
+			 This must be greater than 0 and equal or less than the total connections created from max_step_connections.
+			 Default is 1. A value of 8 when max_step_connections=1 would be a grid.
 
 			\param cores Number of cores to use. -1 will use all available cores, and 0 will run a serialized version of the algorithm.
 			 
@@ -465,6 +470,7 @@ namespace HF::GraphGenerator {
 			down_step_type DownStep,
 			down_slope_type DownSlope,
 			int max_step_connections,
+			int min_connections =1,
 			int cores = -1,
 			z_precision_type node_z_precision = default_z_precision,
 			connect_offset_type  node_spacing_precision = default_spacing_precision,
@@ -480,6 +486,7 @@ namespace HF::GraphGenerator {
 				CastToReal(DownStep),
 				CastToReal(DownSlope),
 				max_step_connections,
+				min_connections,
 				cores,
 				CastToReal(node_z_precision),
 				CastToReal(node_spacing_precision),
@@ -508,6 +515,10 @@ namespace HF::GraphGenerator {
 			 increase the number of edges in the graph, and as a result the amount of memory the
 			 algorithm requires.
 
+			\param min_connections The required out-degree for a node to be valid and stored.
+			 This must be greater than 0 and equal or less than the total connections created from max_step_connections.
+			 Default is 1. A value of 8 when max_step_connections=1 would be a grid.
+
 			\param cores Number of cores to use. -1 will use all available cores, and 0 will run a serialized version of the algorithm.
 			 
 
@@ -531,6 +542,7 @@ namespace HF::GraphGenerator {
 			real_t DownStep,
 			real_t DownSlope,
 			int max_step_connections,
+			int min_connections,
 			int cores = -1,
 			real_t node_z_precision = default_z_precision,
 			real_t node_spacing_precision = default_spacing_precision,

--- a/src/Cpp/analysismethods/src/graph_generator.h
+++ b/src/Cpp/analysismethods/src/graph_generator.h
@@ -470,7 +470,7 @@ namespace HF::GraphGenerator {
 			down_step_type DownStep,
 			down_slope_type DownSlope,
 			int max_step_connections,
-			int min_connections =1,
+			int min_connections = 1,
 			int cores = -1,
 			z_precision_type node_z_precision = default_z_precision,
 			connect_offset_type  node_spacing_precision = default_spacing_precision,

--- a/src/Cpp/tests/src/AnalysisMethods.cpp
+++ b/src/Cpp/tests/src/AnalysisMethods.cpp
@@ -255,6 +255,7 @@ namespace HF {
 			20,
 			1,
 			1,
+			1,
 			-1,
 			default_z_precision,
 			default_spacing_precision,

--- a/src/Cpp/tests/src/AnalysisMethods.cpp
+++ b/src/Cpp/tests/src/AnalysisMethods.cpp
@@ -349,9 +349,10 @@ namespace CInterfaceTests {
 		const float down_step = 2.0;
 		const float down_slope = 0.5;
 		const int maximum_step_connections = 2;
+		const int min_connections = 1;
 		const int cores = 4;
 		
-		if (GenerateGraph(&ert, start, spacing, max_nodes, up_step, up_slope, down_step, down_slope, maximum_step_connections, cores, &g)) {
+		if (GenerateGraph(&ert, start, spacing, max_nodes, up_step, up_slope, down_step, down_slope, maximum_step_connections, min_connections, cores, &g)) {
 			std::cout << "GenerateGraph successful" << std::endl;
 		}
 		else {
@@ -445,6 +446,7 @@ TEST(Performance, GraphGenerator) {
 	float up_slope = 30;
 	float down_slope = 30;
 	int max_step_connections = 1;
+	int min_connections = 1;
 
 
 	// Run Trials and record results
@@ -462,7 +464,8 @@ TEST(Performance, GraphGenerator) {
 			up_slope,
 			down_step,
 			down_slope,
-			max_step_connections
+			max_step_connections,
+			min_connections
 		);
 		watch.StopClock();
 
@@ -487,6 +490,7 @@ TEST(Performance, attrs) {
 	float up_slope = 30;
 	float down_slope = 30;
 	int max_step_connections = 1;
+	int min_connections = 1;
 
 	auto GG = HF::GraphGenerator::GraphGenerator(ray_tracer);
 	auto graph = GG.BuildNetwork(
@@ -497,7 +501,8 @@ TEST(Performance, attrs) {
 		up_slope,
 		down_step,
 		down_slope,
-		max_step_connections
+		max_step_connections,
+		min_connections
 	);
 	graph.Compress();
 

--- a/src/Cpp/tests/src/GraphAlgorithms.cpp
+++ b/src/Cpp/tests/src/GraphAlgorithms.cpp
@@ -127,6 +127,7 @@ namespace HF {
 		double down_step = 5;
 		double down_slope = 60;
 		int max_step_connections = 1;
+		int min_connections = 1;
 		int cores = -1;
 
 
@@ -139,6 +140,7 @@ namespace HF {
 			down_step,
 			down_slope,
 			max_step_connections,
+			min_connections,
 			cores
 		);
 
@@ -158,6 +160,7 @@ namespace HF {
 		double down_step = 5;
 		double down_slope = 60;
 		int max_step_connections = 1;
+		int min_connections = 1;
 		int cores = -1;
 
 
@@ -170,6 +173,7 @@ namespace HF {
 			down_step,
 			down_slope,
 			max_step_connections,
+			min_connections,
 			cores
 		);
 
@@ -193,6 +197,7 @@ namespace HF {
 		double up_step = 1;	double up_slope = 1;
 		double down_step = 1;	double down_slope = 1;
 		int max_step_connections = 1;
+		int min_connections = 1;
 		int cores = -1;
 		std::array<double, 3> start_point{ 1.0, 1.0, 20.0};
 		std::array<double, 3> spacing{ 1, 1, 15};
@@ -200,14 +205,14 @@ namespace HF {
 		auto EmbreeGraph = EmbreeGraphGen.BuildNetwork(
 			start_point, spacing,
 			max_nodes, up_step, up_slope,
-			down_step,	down_slope,	max_step_connections,
+			down_step, down_slope, max_step_connections, min_connections,
 			cores
 		);
 
 		auto NanoGraph = NanoRTGraphGen.BuildNetwork(
 			start_point, spacing,
 			max_nodes, up_step, up_slope,
-			down_step, down_slope, max_step_connections,
+			down_step, down_slope, max_step_connections, min_connections,
 			cores
 		);
 
@@ -241,19 +246,20 @@ namespace HF {
 		double up_step = 50;	double up_slope = 45;
 		double down_step = 50;	double down_slope = 45;
 		int max_step_connections = 2;
+		int min_connections = 1;
 		int cores = -1;
 		std::array<double, 3> start_point{ -22.42, -12.0, 5.0};
 		std::array<double, 3> spacing{ 1.0, 1.0, 10.0 };				
 		auto EmbreeGraph = EmbreeGraphGen.BuildNetwork(
 			start_point, spacing,
 			max_nodes, up_step, up_slope,
-			down_step, down_slope, max_step_connections,
+			down_step, down_slope, max_step_connections, min_connections,
 			cores
 		);
 		auto NanoGraph = NanoRTGraphGen.BuildNetwork(
 			start_point, spacing,
 			max_nodes, up_step, up_slope,
-			down_step, down_slope, max_step_connections,
+			down_step, down_slope, max_step_connections, min_connections,
 			cores
 		);
 

--- a/src/Cpp/tests/src/GraphGenerator.cpp
+++ b/src/Cpp/tests/src/GraphGenerator.cpp
@@ -99,6 +99,7 @@ TEST(_GraphGenerator, BuildNetwork) {
 	int up_step = 1; int down_step = 1;
 	int up_slope = 45; int down_slope = 45;
 	int max_step_connections = 1;
+	int min_connections = 1;
 
 	// Generate the graph using our parameters
 	HF::SpatialStructures::Graph g = GG.BuildNetwork(
@@ -107,7 +108,8 @@ TEST(_GraphGenerator, BuildNetwork) {
 		max_nodes,
 		up_step, down_step,
 		up_slope, down_slope,
-		max_step_connections
+		max_step_connections,
+		min_connections
 	);
 
 	//! [EX_BuildNetwork]
@@ -141,6 +143,7 @@ TEST(_GraphGenerator, OBS_VisTestCase) {
 	int up_step = 20; int down_step = 20;
 	int up_slope = 45; int down_slope = 45;
 	int max_step_connections = 1;
+	int min_connections = 1;
 
 	// Generate a graph without specifying obstacles, this will result on the graph not going on the
 	// boxes due to the low upstep
@@ -150,7 +153,7 @@ TEST(_GraphGenerator, OBS_VisTestCase) {
 		max_nodes,
 		1, 1,
 		up_slope, down_slope,
-		max_step_connections
+		max_step_connections, min_connections
 	);
 
 	HF::GraphGenerator::GraphGenerator GG_Obstacle = GraphGenerator::GraphGenerator(ray_tracer, std::vector<int>{2});
@@ -163,7 +166,7 @@ TEST(_GraphGenerator, OBS_VisTestCase) {
 		max_nodes,
 		up_step, down_step,
 		up_slope, down_slope,
-		max_step_connections
+		max_step_connections, min_connections
 	);
 	
 	obstacle_graph.DumpToJson("Visgraph.json");
@@ -183,6 +186,7 @@ TEST(_GraphGenerator, OBS_BuildNetwork) {
 	int up_step = 1; int down_step = 1;
 	int up_slope = 45; int down_slope = 45;
 	int max_step_connections = 1;
+	int min_connections = 1;
 
 	// Generate the graph using our parameters
 	HF::SpatialStructures::Graph non_obstacle_graph = GG.BuildNetwork(
@@ -191,7 +195,7 @@ TEST(_GraphGenerator, OBS_BuildNetwork) {
 		max_nodes,
 		up_step, down_step,
 		up_slope, down_slope,
-		max_step_connections
+		max_step_connections, min_connections
 	);
 
 	HF::GraphGenerator::GraphGenerator GG_Obstacle = GraphGenerator::GraphGenerator(ray_tracer, std::vector<int>{2});
@@ -203,7 +207,7 @@ TEST(_GraphGenerator, OBS_BuildNetwork) {
 		max_nodes,
 		up_step, down_step,
 		up_slope, down_slope,
-		max_step_connections
+		max_step_connections, min_connections
 	);
 
 	ASSERT_LT(obstacle_graph.size(), non_obstacle_graph.size());
@@ -224,6 +228,7 @@ TEST(_GraphGenerator, CrawlGeom) {
 	int up_step = 1; int down_step = 1;
 	int up_slope = 45; int down_slope = 45;
 	int max_step_connections = 1;
+	int min_connections = 1;
 
 	// Since we're not calling BuildNetwork, we will need to set some parameters
 	// in the GraphGenerator in order to use this function standalone
@@ -232,6 +237,7 @@ TEST(_GraphGenerator, CrawlGeom) {
 	GG.core_count = -1;
 	GG.max_nodes = 5;
 	GG.max_step_connection = 1;
+	GG.min_connections = 1;
 	
 	// Setup its params struct
 	GG.params.up_step = up_step; GG.params.down_step = down_step;

--- a/src/Cpp/tests/src/GraphGenerator.cpp
+++ b/src/Cpp/tests/src/GraphGenerator.cpp
@@ -151,7 +151,7 @@ TEST(_GraphGenerator, OutDegree) {
 	float up_step = 0.5; float down_step = 0.5;
 	int up_slope = 20; int down_slope = 20;
 	int max_step_connections = 1;
-	int min_connections = 1;
+	int min_connections = 4;
 
 	// Generate the graph using our parameters
 	HF::SpatialStructures::Graph g = GG.BuildNetwork(
@@ -170,11 +170,8 @@ TEST(_GraphGenerator, OutDegree) {
 
 	const auto graph_nodes = g.Nodes();
 
-	auto node_count = graph_nodes.size();
+	ASSERT_EQ(graph_nodes.size(), 3412);
 
-	//ASSERT_EQ(graph_nodes.size(), expected_nodes.size());
-
-	//ComparePoints(graph_nodes, expected_nodes);
 }
 
 TEST(_GraphGenerator, OBS_VisTestCase) {

--- a/src/Cpp/tests/src/GraphGenerator.cpp
+++ b/src/Cpp/tests/src/GraphGenerator.cpp
@@ -130,6 +130,53 @@ TEST(_GraphGenerator, BuildNetwork) {
 
 	ComparePoints(graph_nodes, expected_nodes);
 }
+
+
+TEST(_GraphGenerator, OutDegree) {
+	// Load an OBJ containing a simple plane
+	auto mesh = HF::Geometry::LoadMeshObjects("energy_blob_zup.obj", HF::Geometry::ONLY_FILE, false);
+
+	// Create a raytracer using this obj
+	EmbreeRayTracer ray_tracer = HF::RayTracer::EmbreeRayTracer(mesh);
+
+	//! [EX_OutDegree]
+
+	// Create a graphgenerator using the raytracer we just created
+	HF::GraphGenerator::GraphGenerator GG = GraphGenerator::GraphGenerator(ray_tracer);
+
+	// Setup Graph Parameters
+	std::array<float, 3> start_point{ 0,0,20 };
+	std::array<float, 3> spacing{ 1,1,1 };
+	int max_nodes = 5000;
+	int up_step = 0.5; int down_step = 0.5;
+	int up_slope = 20; int down_slope = 20;
+	int max_step_connections = 1;
+	int min_connections = 1;
+
+	// Generate the graph using our parameters
+	HF::SpatialStructures::Graph g = GG.BuildNetwork(
+		start_point,
+		spacing,
+		max_nodes,
+		up_step, down_step,
+		up_slope, down_slope,
+		max_step_connections,
+		min_connections
+	);
+
+	//! [EX_OutDegree]
+
+	auto out_str = PrintGraph(g);
+
+	const auto graph_nodes = g.Nodes();
+
+	auto node_count = graph_nodes.size();
+
+	//ASSERT_EQ(graph_nodes.size(), expected_nodes.size());
+
+	//ComparePoints(graph_nodes, expected_nodes);
+}
+
 TEST(_GraphGenerator, OBS_VisTestCase) {
 	EmbreeRayTracer ray_tracer = CreateObstacleExampleRT("obstacle_vistestcase.obj");
 

--- a/src/Cpp/tests/src/GraphGenerator.cpp
+++ b/src/Cpp/tests/src/GraphGenerator.cpp
@@ -106,8 +106,8 @@ TEST(_GraphGenerator, BuildNetwork) {
 		start_point,
 		spacing,
 		max_nodes,
-		up_step, down_step,
-		up_slope, down_slope,
+		up_step, up_slope,
+		down_step, down_slope,
 		max_step_connections,
 		min_connections
 	);
@@ -148,7 +148,7 @@ TEST(_GraphGenerator, OutDegree) {
 	std::array<float, 3> start_point{ 0,0,20 };
 	std::array<float, 3> spacing{ 1,1,1 };
 	int max_nodes = 5000;
-	int up_step = 0.5; int down_step = 0.5;
+	float up_step = 0.5; float down_step = 0.5;
 	int up_slope = 20; int down_slope = 20;
 	int max_step_connections = 1;
 	int min_connections = 1;
@@ -158,8 +158,8 @@ TEST(_GraphGenerator, OutDegree) {
 		start_point,
 		spacing,
 		max_nodes,
-		up_step, down_step,
-		up_slope, down_slope,
+		up_step, up_slope,
+		down_step, down_slope,
 		max_step_connections,
 		min_connections
 	);

--- a/src/Csharp/packages/base/overall_examples.cs
+++ b/src/Csharp/packages/base/overall_examples.cs
@@ -43,6 +43,7 @@ namespace Humanfctors.Examples
 			float up_slope = 60.0f;
 			float down_slope = 60.0f;
 			int max_step_connections = 1;
+			int min_connections = 1;
 
 			// Generate a graph
 			var graph = DHARTAPI.GraphGenerator.GraphGenerator.GenerateGraph(
@@ -55,6 +56,7 @@ namespace Humanfctors.Examples
 				up_slope,
 				down_slope,
 				max_step_connections,
+				min_connections,
 				-1
 			);
 
@@ -351,6 +353,7 @@ namespace Humanfctors.Examples
 			float down_step = 5;
 			float down_slope = 60;
 			int max_step_connections = 1;
+			int min_connections = 1;
 			int cores = -1;
 
 
@@ -364,6 +367,7 @@ namespace Humanfctors.Examples
 				down_step,
 				down_slope,
 				max_step_connections,
+				min_connections,
 				cores
 			);
 

--- a/src/Csharp/packages/graphgenerator/src/GraphGenerator.cs
+++ b/src/Csharp/packages/graphgenerator/src/GraphGenerator.cs
@@ -65,6 +65,10 @@ namespace DHARTAPI.GraphGenerator
         \param max_step_connections Multiplier for number of children to generate for each node. Increasing this value will
         increase the number of edges in the graph, and as a result the amount of memory the
         algorithm requires.
+        
+        \param min_connections The required out-degree for a node to be valid and stored.
+		This must be greater than 0 and equal or less than the total connections created from max_step_connections.
+		Default is 1. A value of 8 when max_step_connections=1 would be a grid.
 
         \param core_count Number of cores to use. -1 will use all available cores, and 0 will run a serialized version of the algorithm.
 		\param walkable_id IDs of geometry to be considered as obstacles
@@ -104,6 +108,7 @@ namespace DHARTAPI.GraphGenerator
             float down_step = 0.2f,
             float down_slope = 20,
             int max_step_connections = 1,
+            int min_connections =1,
             int core_count = -1,
             int[] obstacle_ids = null,
             int[] walkable_ids = null)
@@ -119,6 +124,7 @@ namespace DHARTAPI.GraphGenerator
                  down_step,
                  down_slope,
                  max_step_connections,
+                 min_connections,
                  core_count,
                  obstacle_ids,
                  walkable_ids

--- a/src/Csharp/packages/graphgenerator/src/GraphGeneratorNative.cs
+++ b/src/Csharp/packages/graphgenerator/src/GraphGeneratorNative.cs
@@ -30,6 +30,9 @@ namespace DHARTAPI.GraphGenerator
 			\param max_step_connections Multiplier for number of children to generate for each node. Increasing this value will
 			increase the number of edges in the graph, and as a result the amount of memory the
 			algorithm requires.
+			\param min_connections The required out-degree for a node to be valid and stored.
+			 This must be greater than 0 and equal or less than the total connections created from max_step_connections.
+			 Default is 1. A value of 8 when max_step_connections=1 would be a grid.
 			\param core_count Number of cores to use. -1 will use all available cores, and 0 will run a serialized version of the algorithm.
 			\param walkable_id IDs of geometry to be considered as obstacles
 			\param obstacle_id IDs of geometry to be considered as walkable surfaces
@@ -48,6 +51,7 @@ namespace DHARTAPI.GraphGenerator
 			float down_step = 0.2f,
 			float down_slope = 20,
 			int max_step_connections = 1,
+			int min_connections =1,
 			int core_count = -1,
 			int[] obstacle_ids = null,
 			int[] walkable_ids = null)
@@ -75,6 +79,7 @@ namespace DHARTAPI.GraphGenerator
 					down_step,
 					down_slope,
 					max_step_connections,
+					min_connections,
 					core_count,
 					ref out_graph
 				);
@@ -91,6 +96,7 @@ namespace DHARTAPI.GraphGenerator
 					down_step,
 					down_slope,
 					max_step_connections,
+					min_connections,
 					core_count,
 					obstacle_ids,
 					walkable_ids,
@@ -118,6 +124,7 @@ namespace DHARTAPI.GraphGenerator
 			float DownStep,
 			float DownSlope,
 			int max_step_connection,
+			int min_connections,
 			int core_count,
 			ref IntPtr out_graph
 		);
@@ -133,6 +140,7 @@ namespace DHARTAPI.GraphGenerator
 			float DownStep,
 			float DownSlope,
 			int max_step_connection,
+			int min_connections,
 			int core_count,
 			int[] obstacle_ids,
 			int[] walkable_ids,

--- a/src/Python/dhart/Examples/GraphGeneratorPlot.py
+++ b/src/Python/dhart/Examples/GraphGeneratorPlot.py
@@ -98,6 +98,38 @@ tolerances and plot a new graph which shows certain areas are not reachable.
     plt.scatter(x, y, c=z, alpha=0.5)
     plt.show()
 
+Using the min_connections parameter we can ensure nodes have a minimum number
+of out directions (out-degree), which can avoid walls/edges and prevent
+'islands' caused by single edge connections
+
+.. plot::
+    :context: close-figs
+
+    # Set a smaller threshold for slope
+    up_slope, down_slope = 5, 5
+
+    min_connections = 8
+
+    # Generate the Graph
+    graph = GenerateGraph(bvh, start_point, spacing, max_nodes,
+                            up_step,up_slope,down_step,down_slope,
+                            max_step_connections, min_connections, cores=-1)
+
+    # Convert the graph to a CSR
+    csr_graph = graph.CompressToCSR()
+
+    # Get the nodes of the graph as a list of x,y,z,type,id tuples
+    nodes = graph.getNodes()
+
+    # get the x,y,z coordinates of the nodes and set the color to the z value
+    x = [ n[0] for n in nodes ] # x coordinate 
+    y = [ n[1] for n in nodes ] # y coordinate 
+    z = [ n[2] for n in nodes ] # z coordinate
+
+    # Plot the graph
+    plt.scatter(x, y, c=z, alpha=0.5)
+    plt.show()
+
 """
 
 import matplotlib.pyplot as plt
@@ -180,5 +212,31 @@ z = [ n[2] for n in nodes ] # z coordinate
 plt.scatter(x, y, c=z, alpha=0.5)
 plt.show()
 
+
+# Set a smaller threshold for slope
+up_slope, down_slope = 5, 5
+
+# Add a minimum out-degree for each node 
+min_connections = 8
+
+# Generate the Graph
+graph = GenerateGraph(bvh, start_point, spacing, max_nodes,
+                        up_step,up_slope,down_step,down_slope,
+                        max_step_connections, min_connections, cores=-1)
+
+# Convert the graph to a CSR
+csr_graph = graph.CompressToCSR()
+
+# Get the nodes of the graph as a list of x,y,z,type,id tuples
+nodes = graph.getNodes()
+
+# get the x,y,z coordinates of the nodes and set the color to the z value
+x = [ n[0] for n in nodes ] # x coordinate 
+y = [ n[1] for n in nodes ] # y coordinate 
+z = [ n[2] for n in nodes ] # z coordinate
+
+# Plot the graph
+plt.scatter(x, y, c=z, alpha=0.5)
+plt.show()
 
 

--- a/src/Python/dhart/Examples/GraphGeneratorPlot.py
+++ b/src/Python/dhart/Examples/GraphGeneratorPlot.py
@@ -217,7 +217,7 @@ plt.show()
 up_slope, down_slope = 5, 5
 
 # Add a minimum out-degree for each node 
-min_connections = 8
+min_connections = 3
 
 # Generate the Graph
 graph = GenerateGraph(bvh, start_point, spacing, max_nodes,

--- a/src/Python/dhart/graphgenerator/graph_generator.py
+++ b/src/Python/dhart/graphgenerator/graph_generator.py
@@ -21,6 +21,7 @@ def GenerateGraph(
     down_step: float = 0.197,
     down_slope: float = 20,
     max_step_connections: int = 1,
+    min_connections: int = 1,
     cores : int = -1,
     obstacle_ids : List[int] = [],
     walkable_ids : List[int] = []
@@ -52,6 +53,9 @@ def GenerateGraph(
         max_step_connections (int, optional): Multiplier for number of children to
             generate for each node. Increasing this value will increase the number of 
             edges in the graph, and as a result the amount of memory the algorithm requires.
+        min_connections (int, optional) The required out-degree for a node to be valid and stored.
+            This must be greater than 0 and equal or less than the total connections created from max_step_connections.
+            Default is 1. A value of 8 when max_step_connections=1 would be a grid.
         cores (int, optional):  Number of cores to use. -1 will use all available cores, 
             and 0 will run a serialized version of the algorithm.
         obstacle_ids : Ids of geometry to consider as obstacles
@@ -130,6 +134,7 @@ def GenerateGraph(
         down_step,
         down_slope,
         max_step_connections,
+        min_connections,
         cores,
         obstacle_ids,
         walkable_ids

--- a/src/Python/dhart/graphgenerator/graph_generator_native_functions.py
+++ b/src/Python/dhart/graphgenerator/graph_generator_native_functions.py
@@ -21,6 +21,7 @@ def GenerateGraph(
     down_step: float,
     down_slope: float,
     max_step_connections: int,
+    min_connections: int,
     cores : int = -1,
     obstacle_geometry: List[int] = [],
     walkable_geometry: List[int] = []
@@ -62,6 +63,7 @@ def GenerateGraph(
             c_float(down_step),
             c_float(down_slope),
             max_step_connections,
+            min_connections,
             c_int(cores),
             byref(graph_ptr)
         )
@@ -81,6 +83,7 @@ def GenerateGraph(
             c_float(down_step),
             c_float(down_slope),
             max_step_connections,
+            min_connections,
             c_int(cores),
             obstacle_array,
             walkable_array,


### PR DESCRIPTION
- Implements the minimum outdegree described in original paper for forcing nodes to be accepted only when a set number of out going edges are valid

When the outdegree is 8, and the max connections is 1, all nodes will have 8 neighbors, and is easy to think of as a grid cell. 