### PR TITLE
Step Type Query

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ set(DEBUG_DEPENDENCY_BINARIES
     "${CMAKE_SOURCE_DIR}/external/Microsoft/cpp/Debug/vcomp140d.dll"
     "${CMAKE_SOURCE_DIR}/external/Microsoft/cpp/Debug/msvcp140d.dll"
 )
-
+ 
 set(RELEASE_DEPENDENCY_BINARIES
     "${CMAKE_SOURCE_DIR}/external/Microsoft/cpp/Release/vcruntime140_1.dll"
     "${CMAKE_SOURCE_DIR}/external/Microsoft/cpp/Release/vcomp140.dll"

--- a/src/CMakeSettings.json
+++ b/src/CMakeSettings.json
@@ -175,6 +175,39 @@
           "type": "BOOL"
         }
       ]
+    },
+    {
+      "name": "x64-Debug-C",
+      "generator": "Visual Studio 17 2022 Win64",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        {
+          "name": "DHARTAPI_Config",
+          "value": "All",
+          "type": "STRING"
+        },
+        {
+          "name": "DHARTAPI_EnableTests",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
+          "name": "DHARTAPI_BuildCSharpTests",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "DHARTAPI_EnableCSharp",
+          "value": "False",
+          "type": "BOOL"
+        }
+      ]
     }
   ]
 }

--- a/src/Cinterface/analysis_C.cpp
+++ b/src/Cinterface/analysis_C.cpp
@@ -126,6 +126,8 @@ C_INTERFACE CalculateAndStoreStepTypes(
 	params.precision.ground_offset = ground_offset;
 	params.precision.node_z = node_z;
 	params.precision.node_spacing = node_spacing;
+	
+	g->Compress();
 
 	auto result = CalculateStepType(*g, HF::RayTracer::MultiRT(ray_tracer), params);
 

--- a/src/Cinterface/analysis_C.cpp
+++ b/src/Cinterface/analysis_C.cpp
@@ -108,28 +108,12 @@ C_INTERFACE GenerateGraphObstacles(
 
 C_INTERFACE CalculateAndStoreStepTypes(
 	HF::SpatialStructures::Graph* g, 
-	HF::RayTracer::EmbreeRayTracer* ray_tracer,
-	float up_step,
-	float down_step,
-	float up_slope,
-	float down_slope,
-	float ground_offset,
-	float node_z,
-	float node_spacing
+	HF::RayTracer::EmbreeRayTracer* ray_tracer
 	) {
-	HF::GraphGenerator::Precision precision = { node_z, node_spacing, ground_offset };
-	HF::GraphGenerator::GraphParams params;
-
-	//Setup params struct
-	params.up_step = up_step; params.down_step = down_step;
-	params.up_slope = up_slope; params.down_slope = down_slope;
-	params.precision.ground_offset = ground_offset;
-	params.precision.node_z = node_z;
-	params.precision.node_spacing = node_spacing;
 	
 	g->Compress();
 
-	auto result = CalculateStepType(*g, HF::RayTracer::MultiRT(ray_tracer), params);
+	auto result = HF::GraphGenerator::CalculateStepType(*g, HF::RayTracer::MultiRT(ray_tracer));
 
 	g->AddEdges(result, "step_type");
 

--- a/src/Cinterface/analysis_C.cpp
+++ b/src/Cinterface/analysis_C.cpp
@@ -105,3 +105,31 @@ C_INTERFACE GenerateGraphObstacles(
 	*out_graph = G;
 	return OK;
 }
+
+C_INTERFACE CalculateAndStoreStepTypes(
+	HF::SpatialStructures::Graph* g, 
+	HF::RayTracer::EmbreeRayTracer* ray_tracer,
+	float up_step,
+	float down_step,
+	float up_slope,
+	float down_slope,
+	float ground_offset,
+	float node_z,
+	float node_spacing
+	) {
+	HF::GraphGenerator::Precision precision = { node_z, node_spacing, ground_offset };
+	HF::GraphGenerator::GraphParams params;
+
+	//Setup params struct
+	params.up_step = up_step; params.down_step = down_step;
+	params.up_slope = up_slope; params.down_slope = down_slope;
+	params.precision.ground_offset = ground_offset;
+	params.precision.node_z = node_z;
+	params.precision.node_spacing = node_spacing;
+
+	auto result = CalculateStepType(*g, HF::RayTracer::MultiRT(ray_tracer), params);
+
+	g->AddEdges(result, "step_type");
+
+	return OK;
+}

--- a/src/Cinterface/analysis_C.h
+++ b/src/Cinterface/analysis_C.h
@@ -230,38 +230,13 @@ C_INTERFACE GenerateGraphObstacles(
 
 	\param		ray_tracer				Raytracer containing the geometry to use for graph generation.
 
-	\param		up_step					Maximum height of a step the graph can traverse.
-										Any steps higher this will be considered inaccessible.
-
-	\param		up_slope				Maximum upward slope the graph can traverse in degrees.
-										Any slopes steeper than this will be considered inaccessible.
-
-	\param		down_step				Maximum step down the graph can traverse.
-										Any steps steeper than this will be considered inaccessible.
-
-	\param		down_slope				The maximum downward slope the graph can traverse.
-										Any slopes steeper than this will be considered inaccessible.
-
-	\param		ground_offset			Distance to offset nodes from the ground before checking line of sight.
-
-	\param		node_z					Precision to round the z-component of nodes after a raycast is performed.
-
-	\param		node_spacing			Precision to round nodes after spacing is calculated.
-
 	\returns	\link HF_STATUS::OK \endlink if query was successful and edges corresponding to step types have been added to the graph.
 */
 
 C_INTERFACE CalculateAndStoreStepTypes(
 	HF::SpatialStructures::Graph* g,
-	HF::RayTracer::EmbreeRayTracer* ray_tracer,
-	float up_step,
-	float down_step,
-	float up_slope,
-	float down_slope,
-	float ground_offset,
-	float node_z,
-	float node_spacing
+	HF::RayTracer::EmbreeRayTracer* ray_tracer
 );
-/**@}*/
+/**@}*/ 
 
 #endif /* ANALYSIS_C_H */

--- a/src/Cinterface/analysis_C.h
+++ b/src/Cinterface/analysis_C.h
@@ -223,6 +223,45 @@ C_INTERFACE GenerateGraphObstacles(
 	HF::SpatialStructures::Graph** out_graph
 );
 
+/*!
+	\brief		Query the graph and identify the step types of all edges, adding them to the graph.
+
+	\param		g						Graph used to query step types.
+
+	\param		ray_tracer				Raytracer containing the geometry to use for graph generation.
+
+	\param		up_step					Maximum height of a step the graph can traverse.
+										Any steps higher this will be considered inaccessible.
+
+	\param		up_slope				Maximum upward slope the graph can traverse in degrees.
+										Any slopes steeper than this will be considered inaccessible.
+
+	\param		down_step				Maximum step down the graph can traverse.
+										Any steps steeper than this will be considered inaccessible.
+
+	\param		down_slope				The maximum downward slope the graph can traverse.
+										Any slopes steeper than this will be considered inaccessible.
+
+	\param		ground_offset			Distance to offset nodes from the ground before checking line of sight.
+
+	\param		node_z					Precision to round the z-component of nodes after a raycast is performed.
+
+	\param		node_spacing			Precision to round nodes after spacing is calculated.
+
+	\returns	\link HF_STATUS::OK \endlink if query was successful and edges corresponding to step types have been added to the graph.
+*/
+
+C_INTERFACE CalculateAndStoreStepTypes(
+	HF::SpatialStructures::Graph* g,
+	HF::RayTracer::EmbreeRayTracer* ray_tracer,
+	float up_step,
+	float down_step,
+	float up_slope,
+	float down_slope,
+	float ground_offset,
+	float node_z,
+	float node_spacing
+);
 /**@}*/
 
 #endif /* ANALYSIS_C_H */

--- a/src/Cpp/analysismethods/src/graph_generator.h
+++ b/src/Cpp/analysismethods/src/graph_generator.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include <array>
 #include <Node.h>
+#include <graph.h>
 #include <cassert>
 #include <variant>
 #include <MultiRT.h>
@@ -26,6 +27,8 @@ namespace HF::SpatialStructures {
 	class Graph;
 	struct Edge;
 	enum STEP;
+	struct Subgraph;
+	struct EdgeSet;
 }
 
 /*! \brief Generate a graph of accessible space from a given start point. 
@@ -780,6 +783,24 @@ namespace HF::GraphGenerator {
 		const real3 & child,
 		RayTracer& rt,
 		const GraphParams & params
+	);
+
+	HF::SpatialStructures::EdgeSet CalculateStepType(
+		const HF::SpatialStructures::Subgraph& sg,
+		RayTracer& rt,
+		const GraphParams& params
+	);
+
+	std::vector<HF::SpatialStructures::EdgeSet> CalculateStepType(
+		const HF::SpatialStructures::Graph& g,
+		RayTracer& rt,
+		const GraphParams& params
+	);
+
+	void CalculateAndStoreStepType(
+		HF::SpatialStructures::Graph& g,
+		RayTracer& rt,
+		const GraphParams& params
 	);
 
 	/*! 

--- a/src/Cpp/analysismethods/src/graph_generator.h
+++ b/src/Cpp/analysismethods/src/graph_generator.h
@@ -761,7 +761,26 @@ namespace HF::GraphGenerator {
 		RayTracer& rt,
 		const GraphParams & params
 	);
+	/*!
+		\brief Determine what kind of step (if any) is between parent and child, given
+			that a connection was verified using the graph generator. 
 
+		\param parent Node being traversed from
+		\param child  Node being traversed to
+		\param rt Raytracer to use for all ray intersections
+
+		\returns The type of step between parent/child.
+
+		\par Example
+		\snippet tests\src\GraphGenerator.cpp EX_GraphGeneratorRayTracer
+		\snippet tests\src\GraphGenerator.cpp EX_CheckConnection
+		`[1,0,0,1]`
+	*/
+	HF::SpatialStructures::STEP CheckConnection(
+		const real3& parent,
+		const real3& child,
+		RayTracer& rt
+	);
 	/*! 
 		\brief Determine what kind of step (if any) is between parent and child.
 	
@@ -787,22 +806,25 @@ namespace HF::GraphGenerator {
 
 	HF::SpatialStructures::EdgeSet CalculateStepType(
 		const HF::SpatialStructures::Subgraph& sg,
-		HF::RayTracer::MultiRT& rt,
-		const GraphParams& params
+		HF::RayTracer::MultiRT& rt
 	);
 
 	std::vector<HF::SpatialStructures::EdgeSet> CalculateStepType(
 		const HF::SpatialStructures::Graph& g,
-		HF::RayTracer::MultiRT& rt,
-		const GraphParams& params
+		HF::RayTracer::MultiRT& rt
 	);
 
 	void CalculateAndStoreStepType(
 		HF::SpatialStructures::Graph& g,
-		HF::RayTracer::MultiRT& rt,
-		const GraphParams& params
+		HF::RayTracer::MultiRT& rt
 	);
 
+	bool CompareCheckConnections(
+		HF::SpatialStructures::Graph& g,
+		RayTracer& rt,
+		const GraphParams& params,
+		std::vector < HF::SpatialStructures::EdgeSet> to_compare
+	);
 	/*! 
 		\brief Determine if there is a valid line of sight between parent and child
 		

--- a/src/Cpp/analysismethods/src/graph_generator.h
+++ b/src/Cpp/analysismethods/src/graph_generator.h
@@ -787,19 +787,19 @@ namespace HF::GraphGenerator {
 
 	HF::SpatialStructures::EdgeSet CalculateStepType(
 		const HF::SpatialStructures::Subgraph& sg,
-		RayTracer& rt,
+		HF::RayTracer::MultiRT& rt,
 		const GraphParams& params
 	);
 
 	std::vector<HF::SpatialStructures::EdgeSet> CalculateStepType(
 		const HF::SpatialStructures::Graph& g,
-		RayTracer& rt,
+		HF::RayTracer::MultiRT& rt,
 		const GraphParams& params
 	);
 
 	void CalculateAndStoreStepType(
 		HF::SpatialStructures::Graph& g,
-		RayTracer& rt,
+		HF::RayTracer::MultiRT& rt,
 		const GraphParams& params
 	);
 

--- a/src/Cpp/analysismethods/src/graph_utils.cpp
+++ b/src/Cpp/analysismethods/src/graph_utils.cpp
@@ -300,7 +300,7 @@ namespace HF::GraphGenerator {
 		return calc_slope > -1.0 * gp.down_slope && calc_slope < gp.up_slope;
 	}
 
-	HF::SpatialStructures::EdgeSet CalculateStepType(const HF::SpatialStructures::Subgraph& sg, RayTracer& rt, const GraphParams& params) {
+	HF::SpatialStructures::EdgeSet CalculateStepType(const HF::SpatialStructures::Subgraph& sg, HF::RayTracer::MultiRT& rt, const GraphParams& params) {
 		// Step type will be stored here and returned from this function
 
 		//Initialize output
@@ -348,7 +348,7 @@ namespace HF::GraphGenerator {
 		return es;
 	}
 
-	std::vector<HF::SpatialStructures::EdgeSet> CalculateStepType(const HF::SpatialStructures::Graph& g, RayTracer& rt, const GraphParams& params) {
+	std::vector<HF::SpatialStructures::EdgeSet> CalculateStepType(const HF::SpatialStructures::Graph& g, HF::RayTracer::MultiRT& rt, const GraphParams& params) {
 		// Retrieve all nodes from g so we can obtain subgraphs.
 		std::vector<HF::SpatialStructures::Node> nodes = g.Nodes();
 
@@ -369,11 +369,13 @@ namespace HF::GraphGenerator {
 		return result;
 	}
 
-	void CalculateAndStoreStepType(HF::SpatialStructures::Graph& g, RayTracer& rt, const GraphParams& params) {
-		// calculates and stores step types of all edges and stores it in the hashmap
+	void CalculateAndStoreStepType(HF::SpatialStructures::Graph& g, HF::RayTracer::MultiRT& rt, const GraphParams& params) {
+		// calculates and stores step types of all edges and stores it in the graph
 
-		// Get vector of edgesets which contain step types
+		// Get all edges with weights corresponding to step type
 		auto result = HF::GraphGenerator::CalculateStepType(g, rt, params);
+
+		// Add edges to the graph
 		g.AddEdges(result, "step_type");
 	}
 

--- a/src/Cpp/analysismethods/src/graph_utils.cpp
+++ b/src/Cpp/analysismethods/src/graph_utils.cpp
@@ -371,10 +371,12 @@ namespace HF::GraphGenerator {
 
 	void CalculateAndStoreStepType(HF::SpatialStructures::Graph& g, HF::RayTracer::MultiRT& rt, const GraphParams& params) {
 		// calculates and stores step types of all edges and stores it in the graph
-		g.Compress()
 
 		// Get all edges with weights corresponding to step type
 		auto result = HF::GraphGenerator::CalculateStepType(g, rt, params);
+
+		// Compression needed before adding edges of alternate cost
+		g.Compress();
 
 		// Add edges to the graph
 		g.AddEdges(result, "step_type");

--- a/src/Cpp/analysismethods/src/graph_utils.cpp
+++ b/src/Cpp/analysismethods/src/graph_utils.cpp
@@ -371,6 +371,7 @@ namespace HF::GraphGenerator {
 
 	void CalculateAndStoreStepType(HF::SpatialStructures::Graph& g, HF::RayTracer::MultiRT& rt, const GraphParams& params) {
 		// calculates and stores step types of all edges and stores it in the graph
+		g.Compress()
 
 		// Get all edges with weights corresponding to step type
 		auto result = HF::GraphGenerator::CalculateStepType(g, rt, params);

--- a/src/Cpp/tests/src/GraphAlgorithms.cpp
+++ b/src/Cpp/tests/src/GraphAlgorithms.cpp
@@ -12,7 +12,6 @@
 #include<ray_data.h>
 
 #include "analysis_C.h"
-#include "graph.h"
 
 namespace HF {
 

--- a/src/Cpp/tests/src/GraphGenerator.cpp
+++ b/src/Cpp/tests/src/GraphGenerator.cpp
@@ -663,5 +663,84 @@ TEST(_GraphGenerator, OcclusionCheck) {
 	ASSERT_FALSE(occlusion_check_child_2);
 }
 
+TEST(_GraphGenerator, CalculateStepType) {
+	EmbreeRayTracer ray_tracer = CreateGGExmapleRT();
+	//! [EX_CheckStepTypes]
+
+	// Create graph parameters
+	HF::GraphGenerator::GraphParams params;
+	params.up_step = 2; params.down_step = 2;
+	params.up_slope = 45; params.down_slope = 45;
+	params.precision.node_z = 0.01f;
+	params.precision.ground_offset = 0.01f;
+
+	Graph g;
+	Node N0 = Node(0, 0, 1);
+	Node N1 = Node(0, 2, 0);
+	Node N2 = Node(1, 0, 0);
+	Node N3 = Node(0, 1, 0);
+	Node N4 = Node(2, 0, 0);
+
+	g.addEdge(N0, N1);
+	g.addEdge(N0, N2);
+	g.addEdge(N0, N3);
+	g.addEdge(N0, N4);
+
+	g.Compress();
+
+	std::vector<HF::SpatialStructures::EdgeSet> step_types = HF::GraphGenerator::CalculateStepType(g, HF::RayTracer::MultiRT(&ray_tracer), params);
+
+	HF::SpatialStructures::EdgeSet node_one_edgeset = step_types[0];
+	std::vector<HF::SpatialStructures::IntEdge> node_one_inteedges = node_one_edgeset.children;
+
+	std::vector<float> expected_step_types = { 1,0,0,1 };
+
+	for (int i = 0; i < expected_step_types.size(); i++) {
+		float step_type = node_one_inteedges[i].weight;
+		ASSERT_EQ(step_type, expected_step_types[i]);
+	}
+	//! [EX_CheckStepTypes]
+}
+
+TEST(_GraphGenerator, CalculateAndStoreStepType) {
+	EmbreeRayTracer ray_tracer = CreateGGExmapleRT();
+	//! [EX_CheckStepTypes]
+
+	// Create graph parameters
+	HF::GraphGenerator::GraphParams params;
+	params.up_step = 2; params.down_step = 2;
+	params.up_slope = 45; params.down_slope = 45;
+	params.precision.node_z = 0.01f;
+	params.precision.ground_offset = 0.01f;
+
+	Graph g;
+	Node N0 = Node(0, 0, 1);
+	Node N1 = Node(0, 2, 0);
+	Node N2 = Node(1, 0, 0);
+	Node N3 = Node(0, 1, 0);
+	Node N4 = Node(2, 0, 0);
+
+	g.addEdge(N0, N1);
+	g.addEdge(N0, N2);
+	g.addEdge(N0, N3);
+	g.addEdge(N0, N4);
+
+	g.Compress();
+
+	CalculateAndStoreStepType(g, HF::RayTracer::MultiRT(&ray_tracer), params);
+
+	std::vector<HF::SpatialStructures::EdgeSet> result = g.GetEdges("step_type");
+
+	HF::SpatialStructures::EdgeSet node_one_edgeset = result[0];
+	std::vector<HF::SpatialStructures::IntEdge> node_one_inteedges = node_one_edgeset.children;
+
+	std::vector<float> expected_step_types = { 1,0,0,1 };
+
+	for (int i = 0; i < expected_step_types.size(); i++) {
+		float step_type = node_one_inteedges[i].weight;
+		ASSERT_EQ(step_type, expected_step_types[i]);
+	}
+
+}
 
 

--- a/src/Python/dhart/graphgenerator/graph_generator.py
+++ b/src/Python/dhart/graphgenerator/graph_generator.py
@@ -146,24 +146,10 @@ def GenerateGraph(
 
 def CalculateAndStoreStepTypes(
     g: Graph,
-    bvh: EmbreeBVH,
-    up_step: float = 0.197,
-    up_slope: float = 20,
-    down_step: float = 0.197,
-    down_slope: float = 20,
-    ground_offset: float = 0.01,
-    node_z: float = 0.0001,
-    node_spacing: float = 0.00001
+    bvh: EmbreeBVH
 ) -> None:
 
     graph_generator_native_functions.CalculateAndStoreStepTypes(
         g.graph_ptr,
-        bvh.pointer,
-        up_step,
-        up_slope,
-        down_step,
-        down_slope,
-        ground_offset,
-        node_z,
-        node_spacing
+        bvh.pointer
     )

--- a/src/Python/dhart/graphgenerator/graph_generator.py
+++ b/src/Python/dhart/graphgenerator/graph_generator.py
@@ -150,6 +150,17 @@ def CalculateAndStoreStepTypes(
 ) -> None:
     """Calculates and stores the step types of all edges in a given graph. It will be stored as cost type "step_type."
 
+    Notes:
+        The C++ code contains an internal mapping from a STEP struct to a float number for compatability purposes.
+        The mapping is as follows:
+            NOT_CONNECTED = 0,  No connection between parent and child.
+            NONE = 1,		    Parent and child are on the same plane and no step is required.
+            UP = 2,			    A step up is required to get from parent to child.
+            DOWN = 3,		    A step down is required to get from parent to child.
+            OVER = 4		    A step over something is required to get from parent to child.
+        In the example below, the step type between Node 0 and Node 1 is looked up and returns the value 3.0. This indicates
+        that the step type to get from node 0 to node 1 is "DOWN."
+
     Args:
         g (Graph): Graph to query step types on.
         bvh (EmbreeBVH): Geometry to use for graph generation. The mesh used

--- a/src/Python/dhart/graphgenerator/graph_generator.py
+++ b/src/Python/dhart/graphgenerator/graph_generator.py
@@ -148,7 +148,46 @@ def CalculateAndStoreStepTypes(
     g: Graph,
     bvh: EmbreeBVH
 ) -> None:
+    """Calculates and stores the step types of all edges in a given graph. It will be stored as cost type "step_type."
 
+    Args:
+        g (Graph): Graph to query step types on.
+        bvh (EmbreeBVH): Geometry to use for graph generation. The mesh used
+            to generate the BVH must have been Z-up.
+
+    Returns:
+        None
+
+    Examples:
+        Generate a graph and query its step types.
+        >>> from dhart.geometry import LoadOBJ, MeshInfo, CommonRotations
+        >>> from dhart.raytracer import EmbreeBVH  
+        >>> from dhart.geometry.mesh_info import ConstructPlane
+        >>> from dhart.graphgenerator import GenerateGraph
+        >>> import dhart
+
+        >>> obj_path = dhart.get_sample_model("energy_blob_zup.obj")
+        >>> obj = LoadOBJ(obj_path)
+        >>> bvh = EmbreeBVH(obj, True)
+
+        >>> start_point = (0, 0, 20)
+        >>> spacing = (1, 1, 1)
+        >>> max_nodes = 5000
+        >>> up_step, down_step = 0.5, 0.5
+        >>> up_slope, down_slope = 20, 20
+        >>> max_step_connections = 1
+        >>> min_connections = 4
+
+        >>> g = GenerateGraph(bvh, start_point, spacing, max_nodes,
+                            up_step,up_slope,down_step,down_slope,
+                            max_step_connections, min_connections)
+
+
+        >>> CalculateAndStoreStepTypes(g, bvh)
+        
+        >>> print(g.GetEdgeCost(0, 1, "step_type"))
+        3.0
+    """
     graph_generator_native_functions.CalculateAndStoreStepTypes(
         g.graph_ptr,
         bvh.pointer

--- a/src/Python/dhart/graphgenerator/graph_generator.py
+++ b/src/Python/dhart/graphgenerator/graph_generator.py
@@ -143,3 +143,27 @@ def GenerateGraph(
         return Graph(pointer)
     else:
         return None
+
+def CalculateAndStoreStepTypes(
+    g: Graph,
+    bvh: EmbreeBVH,
+    up_step: float = 0.197,
+    up_slope: float = 20,
+    down_step: float = 0.197,
+    down_slope: float = 20,
+    ground_offset: float = 0.01,
+    node_z: float = 0.0001,
+    node_spacing: float = 0.00001
+) -> None:
+
+    graph_generator_native_functions.CalculateAndStoreStepTypes(
+        g.graph_ptr,
+        bvh.pointer,
+        up_step,
+        up_slope,
+        down_step,
+        down_slope,
+        ground_offset,
+        node_z,
+        node_spacing
+    )

--- a/src/Python/dhart/graphgenerator/graph_generator_native_functions.py
+++ b/src/Python/dhart/graphgenerator/graph_generator_native_functions.py
@@ -98,4 +98,32 @@ def GenerateGraph(
         return graph_ptr
     elif error_code == HF_STATUS.NO_GRAPH:
         return None
-    
+
+def CalculateAndStoreStepTypes(
+    graph_ptr : c_void_p,
+    rt_ptr: c_void_p,
+    up_step: float,
+    up_slope: float,
+    down_step: float,
+    down_slope: float,
+    ground_offset: float,
+    node_z: float,
+    node_spacing: float
+) -> None:
+    """Queries the graph's step types and adds them as edges to the graph.
+
+    Returns:
+        None
+    """
+    error_code = HFPython.CalculateAndStoreStepTypes(
+        graph_ptr,
+        rt_ptr,
+        c_float(up_step),
+        c_float(down_step),
+        c_float(up_slope),
+        c_float(down_slope),
+        c_float(ground_offset),
+        c_float(node_z),
+        c_float(node_spacing)
+    )
+    assert(error_code == HF_STATUS.OK)

--- a/src/Python/dhart/graphgenerator/graph_generator_native_functions.py
+++ b/src/Python/dhart/graphgenerator/graph_generator_native_functions.py
@@ -102,13 +102,6 @@ def GenerateGraph(
 def CalculateAndStoreStepTypes(
     graph_ptr : c_void_p,
     rt_ptr: c_void_p,
-    up_step: float,
-    up_slope: float,
-    down_step: float,
-    down_slope: float,
-    ground_offset: float,
-    node_z: float,
-    node_spacing: float
 ) -> None:
     """Queries the graph's step types and adds them as edges to the graph.
 
@@ -118,12 +111,5 @@ def CalculateAndStoreStepTypes(
     error_code = HFPython.CalculateAndStoreStepTypes(
         graph_ptr,
         rt_ptr,
-        c_float(up_step),
-        c_float(down_step),
-        c_float(up_slope),
-        c_float(down_slope),
-        c_float(ground_offset),
-        c_float(node_z),
-        c_float(node_spacing)
     )
     assert(error_code == HF_STATUS.OK)

--- a/src/Python/dhart/graphgenerator/test_GraphGenerator.py
+++ b/src/Python/dhart/graphgenerator/test_GraphGenerator.py
@@ -120,8 +120,6 @@ def test_step_type_query():
     g = Graph()
 
     g.AddEdgeToGraph((0,0,1), (0,2,0), -1)
-    g.AddEdgeToGraph((0,0,1), (1,0,0), -1)
-    g.AddEdgeToGraph((0,0,1), (0,1,0), -1)
     g.AddEdgeToGraph((0,0,1), (2,0,0), -1)
 
     up_step, up_slope = 2, 45
@@ -129,13 +127,12 @@ def test_step_type_query():
     node_z = 0.01
     ground_offset = 0.01
 
-    CalculateAndStoreStepTypes(
-        g, bvh, up_step, up_slope, down_step, down_slope, node_z, ground_offset
-    )
+    CalculateAndStoreStepTypes(g, bvh)
 
-    expected_steps = [1, 0, 0, 1]
+    expected_steps = [1,1]
     parent = 0
-    for child in range(1, 5):
+    for child in range(1, 3):
+        print(g.GetEdgeCost(parent, child, "step_type"))
         result_step = g.GetEdgeCost(parent, child, "step_type")
-        assert(result_step == expected_steps[i-1])
+        assert(result_step == expected_steps[child-1])
     


### PR DESCRIPTION
Closes #65 

- Updated CMake to disable C# and added a new build `Debug-C`.
- Implemented C++ methods to query and store all the step types of a given graph (accomplished using C++ functions `CalculateStepType` and 'CalculateAndStoreStepType' in `graph_utils`). 
- C_Interface function `CalculateAndStoreStepTypes` call the previously mentioned C++ methods, also storing all the step types in the given graph.
- Python/C `CalculateAndStoreStepTypes` calls the new C_Interface function to query the step types in the Python interface.
- Added UnitTests corresponding to each of these functions.
- Created overload for `CheckConnection` in `graph_utils` that removes the `params` parameter. This is utilized in `CalculateStepType` and is allowed because we know that the edges are valid after graph generation. 
- Created `CompareCheckConnection` to test equality between the two overloads for `CheckConnection`. Once `CalculateAndStoreStepType(s)` is called, each edge step type found in the resulting `std::vector<EdgeSet>`  is tested against the output of the corresponding step type given by `CheckConnection` with the `params` parameter. This function's purpose was to simplify the appropriate UnitTests.

Attached is a screenshot of all the VS test cases (including three new test cases for the C++ and C_Interface functions, with the exception of `HFUnitTests/CInterfaceTests/C_Pathfinder/CreateManyPathsPerformanceTest` due to runtime issues) and the `test_GraphGenerator.py` test cases passing.
![image](https://github.com/user-attachments/assets/1593b51a-8b39-437a-94f6-d5fe2ef94570)
![image](https://github.com/user-attachments/assets/52db87d0-db17-489c-a785-c1cb0370d48c)

