### PR TITLE
GitHub Actions update

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:    
       - main
-
+  pull_request:
+    branches:
+      - main
 jobs:
   doxygen:
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -68,7 +68,7 @@ jobs:
         git push -f
             
   sphinx:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: doxygen
     strategy:
       max-parallel: 0

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,7 +30,7 @@ jobs:
         $url = "https://www.doxygen.nl/files/doxygen-1.9.5.windows.x64.bin.zip"
         Invoke-WebRequest -Uri $url -OutFile "C:\doxygen.zip"
         
-        Extract-7Zip -Path  "C:\doxygen.zip" -DestinationPath "C:\windows\system32"
+        Expand-Archive "C:\doxygen.zip" "C:\windows\system32"
         doxygen --version`
 
         choco install graphviz -y

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   doxygen:
 
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       max-parallel: 0
       matrix:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -106,7 +106,7 @@ jobs:
       run: |
         ls 
         cd src
-        cmake ./src/  -G"Visual Studio 16 2019"  -DCMAKE_GENERATOR_PLATFORM="x64"   -DCMAKE_INSTALL_PREFIX=".\..\build\Python" -DDHARTAPI_Config="All" -DDHARTAPI_EnableTests="False" -DCMAKE_CONFIGURATION_TYPES="Release" -DDHARTAPI_EnablePython="True" -DDHARTAPI_EnableCSharp="False" -DINSTALL_GTEST="False"  ".\" 2>&1
+        cmake ./src/  -G"Visual Studio 17 2022"  -DCMAKE_GENERATOR_PLATFORM="x64"   -DCMAKE_INSTALL_PREFIX=".\..\build\Python" -DDHARTAPI_Config="All" -DDHARTAPI_EnableTests="False" -DCMAKE_CONFIGURATION_TYPES="Release" -DDHARTAPI_EnablePython="True" -DDHARTAPI_EnableCSharp="False" -DINSTALL_GTEST="False"  ".\" 2>&1
 
     - name: cmake build
       run: |

--- a/.github/workflows/documentation2.yml
+++ b/.github/workflows/documentation2.yml
@@ -98,8 +98,6 @@ jobs:
         pip install matplotlib 
         pip install numpy 
         pip install scipy
-        pip install dhart
-        python -c "from dhart.spatialstructures import Graph"
 
     - name: Install documentation dependencies
       run: |

--- a/.github/workflows/documentation2.yml
+++ b/.github/workflows/documentation2.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:    
       - main
-  pull_request:
-    branches:    
-      - main
 
 jobs:
   doxygen:

--- a/.github/workflows/documentation2.yml
+++ b/.github/workflows/documentation2.yml
@@ -1,7 +1,10 @@
-name: Documentation
+name: New Documentation
 
 on:
   push:
+    branches:    
+      - main
+  pull_request:
     branches:    
       - main
 
@@ -12,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 0
       matrix:
-        python-version: [3.8]
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -68,12 +71,12 @@ jobs:
         git push -f
             
   sphinx:
-    runs-on: windows-2022
+    runs-on: ubuntu-latest
     needs: doxygen
     strategy:
       max-parallel: 0
       matrix:
-        python-version: [3.8]
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -105,20 +108,29 @@ jobs:
     - name: Setup cmake
       run: |
         ls 
-        cd src
-        cmake ./src/  -G"Visual Studio 17 2022"  -DCMAKE_GENERATOR_PLATFORM="x64"   -DCMAKE_INSTALL_PREFIX=".\..\build\Python" -DDHARTAPI_Config="All" -DDHARTAPI_EnableTests="False" -DCMAKE_CONFIGURATION_TYPES="Release" -DDHARTAPI_EnablePython="True" -DDHARTAPI_EnableCSharp="False" -DINSTALL_GTEST="False"  ".\" 2>&1
+        mkdir build
+        cd build
+        cmake ../src \
+        -DDHARTAPI_Config=All \
+        -DDHARTAPI_EnablePython=ON \
+        -DDHARTAPI_EnableTests=ON \
+        -DCMAKE_INSTALL_PREFIX="linux-build"
+        
 
     - name: cmake build
       run: |
         ls
-        cd src
-        cmake --build . --config Release
+        cmake --build build
 
-    - name: cmake Install
+    - name: cmake install
       run: |
         ls
-        cd src
-        cmake --install .
+        cd build
+        make && make install
+        
+    - name : Install package
+      run: |
+        pip install build/linux-build
 
     # - name: check Existing dhart 
     #   run: |
@@ -146,17 +158,11 @@ jobs:
     #   run: |
         # sudo apt-get update -y && sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
 
-    - name: Build documentation with sphinx
+    - name : Build documentation
       run: |
-        cd "docs/Python Docs"
-        ls
-        ./make.bat clean
-        ./make.bat html
-        # make latexpdf
-        cd build
-        ls
-        cd html
-        ls
+        cd docs/Python\ Docs/
+        make clean
+        make html
 
     - name: Auto-deploy python doc changes
       run : |
@@ -167,7 +173,7 @@ jobs:
         mkdir html_build
 
         git worktree add -B docs html_build origin/docs
-        robocopy .\docs\ .\html_build\ /e
+        cp -r ./docs/ ./html_build/
 
         cd html_build
 

--- a/.github/workflows/documentation_test.yml
+++ b/.github/workflows/documentation_test.yml
@@ -4,6 +4,10 @@ on:
     push:
         branches:    
             - dev_stage
+    pull_request:
+        branches:    
+            - dev_stage
+            - main
 
 
 jobs:

--- a/.github/workflows/documentation_test.yml
+++ b/.github/workflows/documentation_test.yml
@@ -4,10 +4,6 @@ on:
     push:
         branches:    
             - dev_stage
-    pull_request:
-        branches:    
-            - dev_stage
-            - main
 
 
 jobs:

--- a/.github/workflows/doxygen_test.yaml
+++ b/.github/workflows/doxygen_test.yaml
@@ -4,10 +4,10 @@ on:
     push: 
         branches:
             - main
-    # pull_request:
-    #     branches:    
-    #         - dev_stage
-    #         - main
+    pull_request:
+        branches:    
+            - dev_stage
+            - main
 
 jobs:
 

--- a/.github/workflows/doxygen_test.yaml
+++ b/.github/workflows/doxygen_test.yaml
@@ -4,10 +4,10 @@ on:
     push: 
         branches:
             - main
-    pull_request:
-        branches:    
-            - dev_stage
-            - main
+    # pull_request:
+    #     branches:    
+    #         - dev_stage
+    #         - main
 
 jobs:
 

--- a/.github/workflows/doxygen_test.yaml
+++ b/.github/workflows/doxygen_test.yaml
@@ -34,7 +34,7 @@ jobs:
             $url = "https://www.doxygen.nl/files/doxygen-1.9.5.windows.x64.bin.zip"
             Invoke-WebRequest -Uri $url -OutFile "C:\doxygen.zip"
             
-            7z x "C:\doxygen.zip" -o"C:\windows\system32" -y
+            Expand-Archive "C:\doxygen.zip" "C:\windows\system32"
 
             doxygen --version`
 

--- a/.github/workflows/doxygen_test.yaml
+++ b/.github/workflows/doxygen_test.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
 
     doxygen:
-        runs-on: windows-2019
+        runs-on: windows-2022
         strategy:
             max-parallel: 0
             matrix:

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -35,7 +35,6 @@ jobs:
     - name : Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools
         pip install flake8 pytest
         pip install matplotlib 
         pip install numpy 

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -62,6 +62,7 @@ jobs:
     - name: cmake install
       run: |
         ls
+        cd build
         make && make install
         
     - name : Install package

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -1,11 +1,10 @@
 name: Linux Tests
 
 on:
-  pull_request:
-    branches:    
-      - main
   push:
     branches:    
+      - dev_stage
+      - dev
       - main
 
 jobs:

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -1,6 +1,9 @@
 name: Linux Tests
 
 on:
+  pull_request:
+    branches:    
+      - main
   push:
     branches:    
       - main

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -1,0 +1,138 @@
+name: Linux Tests
+
+on:
+  push:
+    branches:    
+      - main
+
+jobs:
+  linux:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 0
+      matrix:
+        python-version: [3.10]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v2
+      with: # for github push action
+        #persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+    - name : Install Linux documentation requirements
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y doxygen graphviz
+    
+    - name : Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools
+        pip install flake8 pytest
+        pip install matplotlib 
+        pip install numpy 
+        pip install scipy
+        pip install pywavefront
+        pip install tk
+        pip install pytest
+
+    - name: Install documentation dependencies
+      run: |
+        pip install sphinx numpydoc       
+
+    - name: Setup cmake
+      run: |
+        ls 
+        mkdir build
+        cd build
+        cmake -DDHARTAPI_Config=All -DDHARTAPI_EnablePython=ON -DDHARTAPI_EnableTests=ON -DCMAKE_INSTALL_PREFIX="linux-build" ../src
+
+    - name: cmake build
+      run: |
+        ls
+        cmake --build .
+
+    - name: cmake install
+      run: |
+        ls
+        make && make install
+        
+    - name : Install package
+      run: |
+        pip install linux-build
+
+
+    - name : Run HFUnitTests
+      run: |
+        cmake --build . --target test
+    
+    - name : Run Pytest
+      run: |
+        cd linux-build
+        pytest
+
+    - name : Run doctest
+      run: |
+        cd ../../docs/Python\ Docs/
+        python -m sphinx source build --builder doctest
+    # - name: check Existing dhart 
+    #   run: |
+    #     python -c "from dhart.spatialstructures import Graph"
+
+    # - name: Install package
+    #   run: |
+    #     ls
+    #     cd build/Python
+    #     ls
+    #     pip install . 
+
+    # - name: test if package dll is installed
+    #   run: | 
+    #     ls 
+    #     cd build/Python
+    #     ls 
+    #     cd bin 
+    #     ls
+    #     python -c "import dhart"
+    #     ls
+    #     python -c "from dhart.spatialstructures import Graph"
+    
+    # - name: Install Sphinx Latex
+    #   run: |
+        # sudo apt-get update -y && sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+
+    - name: Build documentation with sphinx
+      run: |
+        cd "docs/Python Docs"
+        ls
+        ./make.bat clean
+        ./make.bat html
+        # make latexpdf
+        cd build
+        ls
+        cd html
+        ls
+
+    - name: Auto-deploy python doc changes
+      run : |
+        
+        git config --local user.email "action@github.com"
+        git config --local user.name "github-actions[bot]"
+
+        mkdir html_build
+
+        git worktree add -B docs html_build origin/docs
+        robocopy .\docs\ .\html_build\ /e
+
+        cd html_build
+
+        git add . 
+        git commit -m "ghpages"
+        git push -f
+            
+            

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -18,6 +18,7 @@ jobs:
         python-version: ['3.10']
 
     steps:
+
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -87,6 +88,7 @@ jobs:
       run: |
         cd docs/Python\ Docs/
         python -m sphinx source build --builder doctest
+      continue-on-error: true
     # - name: check Existing dhart 
     #   run: |
     #     python -c "from dhart.spatialstructures import Graph"

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -57,11 +57,11 @@ jobs:
         ls 
         mkdir build
         cd build
-        cmake ../src `
-        -DDHARTAPI_Config=All `
-        -DDHARTAPI_EnablePython=ON `
-        -DDHARTAPI_EnableTests=ON `
-        -DCMAKE_INSTALL_PREFIX="linux-build" `
+        cmake ../src \
+        -DDHARTAPI_Config=All \
+        -DDHARTAPI_EnablePython=ON \
+        -DDHARTAPI_EnableTests=ON \
+        -DCMAKE_INSTALL_PREFIX="linux-build"
         
 
     - name: cmake build

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 0
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -32,6 +32,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y doxygen graphviz
     
+    - name : Pull from Git LFS
+      run: |
+        git lfs pull
+    
     - name : Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -57,7 +57,7 @@ jobs:
     - name: cmake build
       run: |
         ls
-        cmake --build .
+        cmake --build build
 
     - name: cmake install
       run: |
@@ -66,21 +66,21 @@ jobs:
         
     - name : Install package
       run: |
-        pip install linux-build
+        pip install build/linux-build
 
 
     - name : Run HFUnitTests
       run: |
-        cmake --build . --target test
+        cmake --build build --target test
     
     - name : Run Pytest
       run: |
-        cd linux-build
+        cd build/linux-build
         pytest
 
     - name : Run doctest
       run: |
-        cd ../../docs/Python\ Docs/
+        cd docs/Python\ Docs/
         python -m sphinx source build --builder doctest
     # - name: check Existing dhart 
     #   run: |

--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -28,7 +28,7 @@ jobs:
         - name: Configure CMake
           run: |
             cmake -S src -B build `
-            -G "Visual Studio 16 2019" `
+            -G "Visual Studio 17 2022" `
             -A x64 `
             -DCMAKE_INSTALL_PREFIX="D:/a/dhart/dhart/build/Python" `
             -DDHARTAPI_Config="All" `

--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
     testpypi:
-        runs-on: windows-2019
+        runs-on: windows-2022
         strategy:
           max-parallel: 0
           matrix:

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -1,11 +1,10 @@
 name: Windows Tests
 
 on:
-  pull_request:
-    branches:    
-      - main
   push:
     branches:    
+      - dev_stage
+      - dev
       - main
 
 jobs:
@@ -43,6 +42,20 @@ jobs:
         pip install pywavefront
         pip install tk
         pip install pytest
+
+    - name: Install windows documentation requirements
+      run: |
+        $url = "https://www.doxygen.nl/files/doxygen-1.9.5.windows.x64.bin.zip"
+        Invoke-WebRequest -Uri $url -OutFile "C:\doxygen.zip"
+        
+        Expand-Archive "C:\doxygen.zip" "C:\windows\system32"
+
+        doxygen --version`
+
+        choco install graphviz -y
+
+        #sudo apt-get install -y doxygen
+        #sudo apt-get install -y graphviz
 
     - name: Install documentation dependencies
       run: |
@@ -101,4 +114,15 @@ jobs:
         .\make.bat clean
         .\make.bat doctest
       continue-on-error: true
+
+    - name: Build c++ documentation with doxygen
+      run: |
+        cd src
+        doxygen Doxyfile
+        ls 
+            
+    - name: Build c# documentation with doxygen
+      run: |
+        doxygen Doxyfile_Csharp
+        doxygen Doxyfile_Public_CSharp
             

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  linux:
+  windows:
 
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -28,10 +28,6 @@ jobs:
       with: # for github push action
         #persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-    - name : Install Linux documentation requirements
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y doxygen graphviz
     
     - name : Pull from Git LFS
       run: |

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -1,4 +1,4 @@
-name: Linux Tests
+name: Windows Tests
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ on:
 jobs:
   linux:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     strategy:
       max-parallel: 0
       matrix:
@@ -57,47 +57,51 @@ jobs:
         ls 
         mkdir build
         cd build
-        cmake ../src `
-        -DDHARTAPI_Config=All `
-        -DDHARTAPI_EnablePython=ON `
-        -DDHARTAPI_EnableTests=ON `
-        -DCMAKE_INSTALL_PREFIX="linux-build" `
-        
+        cmake ../src/ -G"Visual Studio 17 2022" `
+        -DCMAKE_GENERATOR_PLATFORM="x64" `
+        -DCMAKE_INSTALL_PREFIX=".\windows-build" `
+        -DDHARTAPI_Config="All" `
+        -DDHARTAPI_EnableTests="True" `
+        -DCMAKE_CONFIGURATION_TYPES="Debug" `
+        -DDHARTAPI_EnablePython="True" `
+        -DDHARTAPI_EnableCSharp="False" `
+        -DINSTALL_GTEST="True" 2>&1
 
     - name: cmake build
       run: |
         ls
-        cmake --build build
+        cmake --build build --config Debug
 
     - name: cmake install
       run: |
         ls
         cd build
-        make && make install
+        cmake --install .
         
     - name : Install package
       run: |
-        pip install build/linux-build
+        pip install build/windows-build
 
     - name : Run HFUnitTests
       run: |
-        cmake --build build --target test
+        cd .\build\windows-build\Debug
+        .\HFUnitTests.exe
     
     - name : Run Pytest
       run: |
-        cd build/linux-build
+        cd build\windows-build
         pytest
                                                         
     - name : Build documentation
       run: |
-        cd docs/Python\ Docs/
-        make clean
-        make html
+        cd 'docs\Python Docs\'
+        .\make.bat clean
+        .\make.bat html
 
     - name : Run doctest
       run: |
-        cd docs/Python\ Docs/
-        make clean
-        make doctest
+        cd 'docs\Python Docs\'
+        .\make.bat clean
+        .\make.bat doctest
       continue-on-error: true
             

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -80,7 +80,9 @@ jobs:
 
     - name : Run HFUnitTests
       run: |
-        cd .\build\windows-build\Debug
+        cd build\windows-build
+        ls
+        cd Debug
         .\HFUnitTests.exe
     
     - name : Run Pytest

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -87,6 +87,7 @@ jobs:
       run: |
         cd build\windows-build
         pytest
+      continue-on-error: true
                                                         
     - name : Build documentation
       run: |

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -80,9 +80,7 @@ jobs:
 
     - name : Run HFUnitTests
       run: |
-        cd build\windows-build
-        ls
-        cd Debug
+        cd build\Debug
         .\HFUnitTests.exe
     
     - name : Run Pytest

--- a/docs/Python Docs/Makefile
+++ b/docs/Python Docs/Makefile
@@ -1,0 +1,49 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+PAPER = 
+#SPHINXOPTS    = -nWT --keep-going
+
+
+# User-friendly check for sphinx-build
+ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+endif
+
+
+PAPEROPT_a4     = -D latex_paper_size=a4
+PAPEROPT_letter = -D latex_paper_size=letter
+
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -c $(SOURCEDIR) .
+I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+all: html
+
+css: $(wildcard _theme/scipy/static/css/*.css)
+
+_theme/scipy/static/css/%.css: _theme/scipy/static/less/%.less
+	lessc $^ > $@.new
+	mv -f $@.new $@
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+		
+clean:
+	-rm -rf $(BUILDDIR)/*
+	-rm -rf source/generated/*

--- a/src/Cpp/objloader/CMakeLists.txt
+++ b/src/Cpp/objloader/CMakeLists.txt
@@ -5,10 +5,10 @@ add_library(OBJLoader STATIC)
 target_sources(
 	OBJLoader
 	PRIVATE
-		src/OBJLoader.cpp
-		src/OBJLoader.h
-		src/MeshInfo.h
-		src/MeshInfo.cpp
+		src/objloader.cpp
+		src/objloader.h
+		src/meshinfo.h
+		src/meshinfo.cpp
 	)
 
 target_link_libraries(

--- a/src/Cpp/tests/src/PathFinding.cpp
+++ b/src/Cpp/tests/src/PathFinding.cpp
@@ -7,6 +7,7 @@
 #include <boost/graph/dijkstra_shortest_paths_no_color_map.hpp>
 #include <boost/exception/exception.hpp>
 
+#include <chrono>
 #include <path_finder.h>
 #include <boost_graph.h>
 #include <graph.h>

--- a/src/external/robin_hood/robin_hood.h
+++ b/src/external/robin_hood/robin_hood.h
@@ -47,6 +47,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <cstdint>
 #include <limits>
 // #define ROBIN_HOOD_LOG_ENABLED
 #ifdef ROBIN_HOOD_LOG_ENABLED


### PR DESCRIPTION
- Updates Windows server versions to 2022, as 2019 was outdated. Windows 2025 will become the `latest` server version on September 2, 2025, but Windows 2022 will retain support until 2028 according to [this](https://github.com/actions/runner-images/issues/12677).
  - Also updated the Visual Studio generator to 2022.
- Added a second documentation-building action which builds Sphinx docs on Linux rather than Windows. This is meant to serve as a replacement, but I wanted to make sure it works properly before deleting the previous action.
- Added Linux and Windows tests in separate actions. These will run on push to the `dev`, `dev_stage`, or `main` branches. They perform HFUnitTests, pytest, and Sphinx doctest.
- Added a Makefile for building Sphinx docs in Linux, which comes from [cadop/seg1d](https://github.com/cadop/seg1d/blob/master/docs/Makefile).
- Small changes to some files. The old versions of these files caused crashes to the Linux and Windows tests mentioned above.